### PR TITLE
Fix: Sign in here link now navigates to login page

### DIFF
--- a/src/Registration.jsx
+++ b/src/Registration.jsx
@@ -282,12 +282,12 @@ const RegistrationForm = () => {
                         <div className="text-center pt-4 border-t border-gray-100">
                             <p className="text-sm text-gray-600">
                                 Already have an account?{' '}
-                                <button 
-                                    onClick={() => alert('Navigate to login page')}
+                                <Link 
+                                    to="/login"
                                     className="font-semibold text-blue-600 hover:text-blue-700 transition-colors hover:underline cursor-pointer"
                                 >
                                     Sign in here
-                                </button>
+                                </Link>
                             </p>
                         </div>
                     </div>


### PR DESCRIPTION
#121 
The problem is when a user clicks on the "Sign in here" link at the bottom of the registration form, instead of navigating directly to the login page, an alert pops up saying “Navigate to login page” and nothing happens after that. So the user has to manually go to the login page which breaks the flow of navigation and is frustrating. The user wants a smooth experience where clicking the "Sign in here" link should directly take them to the login page without showing any alert or requiring extra steps.

Can see what was happening earlier
 
![issuessss](https://github.com/user-attachments/assets/7db4e90c-89de-42ef-bdfd-ae046424bfb2)

## Solution
I fixed the issue by replacing the alert logic with a direct navigation using React Router’s <Link> component. The original implementation showed an alert saying "Navigate to login page" but did not actually perform any routing.

To solve this, I added a proper <Link> tag that redirects the user to the login page smoothly, without any popups or manual navigation. Now, when the user clicks on “Sign in here”, they are taken to the login page instantly.

I have created the navigation link as:
                 ```jsx
<div className="text-center pt-4 border-t border-gray-100">
  <p className="text-sm text-gray-600">
    Already have an account?{' '}
    <Link 
      to="/login"
      className="font-semibold text-blue-600 hover:text-blue-700 transition-colors hover:underline cursor-pointer"
    >
      Sign in here
    </Link>
  </p>
</div>
```




This now provides a much better and expected user experience, just like most modern signup forms.

The preview of the solution is in the video below:

https://github.com/user-attachments/assets/34972bc2-9898-41b6-b353-6696fa5473b



